### PR TITLE
fix: Have main deploy to prod

### DIFF
--- a/.github/workflows/main_build.yaml
+++ b/.github/workflows/main_build.yaml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   deploy:
-    name: Build and release to dev
+    name: Build and release to prod
     uses: ./.github/workflows/patch_build_and_release.yaml
     with:
-      environment: dev
+      environment: prod
     secrets: inherit

--- a/.github/workflows/manual_patch_release.yaml
+++ b/.github/workflows/manual_patch_release.yaml
@@ -6,7 +6,7 @@ on:
       environment:
         description: "Deployment Environment"
         required: true
-        default: "dev"
+        default: "prod"
         type: choice
         options:
           - dev

--- a/patch-release.sh
+++ b/patch-release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 uesio login
 uesio work
 npm run push


### PR DESCRIPTION
# What does this PR do?

1. Updates main branch build to deploy to Prod. We don't / can't really deploy to the "ues-dev" environment anymore because CRM isn't deploying there anymore, so the dependent bundles wouldn't work.
2. Prevents the "patch release" script from running subsequent steps if any individual line in the script fails. (set -e ) does this
