### PR TITLE
articles_image_field_add

### DIFF
--- a/bundle/fields/uesio/cms/article/image.yaml
+++ b/bundle/fields/uesio/cms/article/image.yaml
@@ -1,0 +1,5 @@
+name: image
+label: Image
+type: FILE
+file:
+  accept: ANY

--- a/generated/@types/@uesio/index.d.ts
+++ b/generated/@types/@uesio/index.d.ts
@@ -168,17 +168,17 @@ type CallBot = (
 interface BeforeSaveBotApi {
 	addError: (error: string) => void
 	load: (loadRequest: LoadRequest) => Record<string, FieldValue>[]
+	save: (collectionName: string, records: WireRecord[]) => void
+	delete: (collectionName: string, records: WireRecord[]) => void
 	deletes: DeletesApi
 	inserts: InsertsApi
 	updates: UpdatesApi
 	callBot: CallBot
+	runIntegrationAction: RunIntegrationAction
+	getConfigValue: (configValueKey: string) => string
 	log: LogApi
 }
 interface AfterSaveBotApi extends BeforeSaveBotApi {
-	save: (collectionName: string, records: WireRecord[]) => void
-	delete: (collectionName: string, records: WireRecord[]) => void
-	runIntegrationAction: RunIntegrationAction
-	getConfigValue: (configValueKey: string) => string
 	asAdmin: AsAdminApi
 }
 interface AsAdminApi {
@@ -423,6 +423,7 @@ interface SaveBotApi {
 	log: LogApi
 	http: HttpApi
 	callBot: CallBot
+	load: (loadRequest: LoadRequest) => Record<string, FieldValue>[]
 }
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
@@ -552,7 +553,7 @@ export type {
 }
 declare module "@uesio/ui" {
 import { FC, ReactNode } from "react"
-import { Class } from "@twind/core"
+import { Class, cx } from "@twind/core"
 
 type FieldMode = "READ" | "EDIT"
 
@@ -777,6 +778,7 @@ declare function useStyleTokens(
 export const styles = {
 	useUtilityStyleTokens,
 	useStyleTokens,
+	cx,
 }
 
 //
@@ -792,6 +794,10 @@ interface SlotUtilityProps extends UtilityProps {
 	componentType?: MetadataKey
 }
 
+interface UtilityPropsPlus extends UtilityProps {
+	[x: string]: unknown
+}
+
 export namespace component {
 	export namespace registry {
 		export function register(key: MetadataKey, componentType: UC): void
@@ -804,6 +810,9 @@ export namespace component {
 	export function Slot(
 		...args: Parameters<FC<SlotUtilityProps>>
 	): ReturnType<FC>
+	export function getUtility<T extends UtilityProps = UtilityPropsPlus>(
+		key: MetadataKey
+	): UtilityComponent<T>
 }
 
 //
@@ -1167,6 +1176,10 @@ type WireRecord = {
 	 * @param context Context - the context in which to perform the update
 	 */
 	update: (fieldId: string, value: FieldValue, context: Context) => void
+	/**
+	 * Remove a record from the wire
+	 */
+	remove: () => void
 }
 
 type OrderState = {


### PR DESCRIPTION
# What does this PR do?

Add an image field to the articles collection for the web app so that we can upload an image to the blog page and reference it in the markdown.