### PR TITLE
update _footer

### DIFF
--- a/bundle/views/footer.yaml
+++ b/bundle/views/footer.yaml
@@ -32,13 +32,9 @@ definition:
                             root: []
                       - uesio/io.box:
                           components:
-                            - uesio/io.markdown:
-                                markdown: "# [CIO Review Magazine Award 2024](https://www.cioreview.com/ues-io) "
-                                uesio.styleTokens:
-                                  root:
-                                    - text-white
-                                  a:
-                                    - text-sm
+                            - uesio/io.link:
+                                text: CIO Review Magazine 2024 Award
+                                link: https://www.cioreview.com/ues-io
                           uesio.styleTokens:
                             root:
                               - mt-4


### PR DESCRIPTION
Removed the "uesio/io.markdown e[0].replace is not a function" error

# What does this PR do?

I removed the markdown component form the footer and replaced it with a link instead.

The link is to the CIO Review magazine Award 2024

I also created a new package and updated the site so as to make the change immediate.